### PR TITLE
BOOST paths fixed for the boost version 1.69

### DIFF
--- a/p4scl.spec
+++ b/p4scl.spec
@@ -168,7 +168,7 @@ export CPLUS_INCLUDE_PATH="/usr/local/include:%{_scl_root}/usr/include\${CPLUS_I
 
 # Setup boost environment to newest version
 export BOOST_INCLUDEDIR=/usr/include/boost169
-export BOOST_LIBRARYDIR=/usr/lib64/:/usr/lib64/boost169
+export BOOST_LIBRARYDIR=/usr/lib64/boost169
 
 echo "*************************************************************************"
 echo "WARNING: Use cmake3 instead of cmake"

--- a/p4scl.spec
+++ b/p4scl.spec
@@ -158,8 +158,8 @@ cat >> %{buildroot}%{_scl_scripts}/enable << -EOF
 source scl_source enable devtoolset-6
 # Enable the remaining parts for the P4 scl
 export PATH="%{_bindir}:%{_sbindir}\${PATH:+:\${PATH}}"
-export LIBRARY_PATH="/usr/local/lib:%{_libdir}:%{_scl_root}/usr/lib\${LIBRARY_PATH:+:\${LIBRARY_PATH}}"
-export LD_LIBRARY_PATH="/usr/local/lib:%{_libdir}:%{_scl_root}/usr/lib\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
+export LIBRARY_PATH="/usr/lib64/boost169:/usr/local/lib:%{_libdir}:%{_scl_root}/usr/lib\${LIBRARY_PATH:+:\${LIBRARY_PATH}}"
+export LD_LIBRARY_PATH="/usr/lib64/boost169:/usr/local/lib:%{_libdir}:%{_scl_root}/usr/lib\${LD_LIBRARY_PATH:+:\${LD_LIBRARY_PATH}}"
 export MANPATH="%{_mandir}:\${MANPATH:-}"
 export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:%{_libdir}/pkgconfig:%{_scl_root}/usr/lib/pkgconfig\${PKG_CONFIG_PATH:+:\${PKG_CONFIG_PATH}}"
 export PYTHONPATH="/usr/local/lib64/python2.7/site-packages:%{_scl_root}/usr/lib64/python2.7/site-packages\${PYTHONPATH:+:\${PYTHONPATH}}"
@@ -168,7 +168,7 @@ export CPLUS_INCLUDE_PATH="/usr/local/include:%{_scl_root}/usr/include\${CPLUS_I
 
 # Setup boost environment to newest version
 export BOOST_INCLUDEDIR=/usr/include/boost169
-export BOOST_LIBRARYDIR=/usr/lib64/boost169
+export BOOST_LIBDIR=/usr/lib64/boost169
 
 echo "*************************************************************************"
 echo "WARNING: Use cmake3 instead of cmake"

--- a/test/test-build.sh
+++ b/test/test-build.sh
@@ -20,7 +20,7 @@ scl enable p4lang-p4-1 - << -EOF
     cd p4c.git
     mkdir build extensions
     cd build 
-    cmake3 ..
+    cmake3 -DBoost_DEBUG=on ..
     make -j1
     make install
     popd


### PR DESCRIPTION
This version fixes paths passed to the Cmake, where the first path was not compatible with passed header files.